### PR TITLE
add a continuous random event generator

### DIFF
--- a/random_traffic.zsh
+++ b/random_traffic.zsh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+
+while true; do
+  DICE=$((RANDOM %= 100))
+  if [[ $DICE < 40 ]]; then
+    zsh ./login_from_new_client.sh;
+  elif [[ $DICE < 70 ]]; then
+    zsh ./login_from_new_region.sh;
+  elif [[ $DICE < 90 ]]; then
+    zsh ./forgetful_user.sh;
+  elif [[ $DICE < 93 ]]; then
+    zsh ./credential_stuffing.sh;
+  elif [[ $DICE < 96 ]]; then
+    zsh ./brute_force.sh;
+  elif [[ $DICE > 101 ]]; then
+    zsh ./brute_force_botnet.sh;
+  fi
+  date ;
+  sleep 60;
+done

--- a/random_traffic.zsh
+++ b/random_traffic.zsh
@@ -2,17 +2,17 @@
 
 while true; do
   DICE=$((RANDOM %= 100))
-  if [[ $DICE < 40 ]]; then
+  if [[ $DICE < 60 ]]; then
     zsh ./login_from_new_client.sh;
-  elif [[ $DICE < 70 ]]; then
-    zsh ./login_from_new_region.sh;
   elif [[ $DICE < 90 ]]; then
+    zsh ./login_from_new_region.sh;
+  elif [[ $DICE < 94 ]]; then
     zsh ./forgetful_user.sh;
-  elif [[ $DICE < 93 ]]; then
-    zsh ./credential_stuffing.sh;
   elif [[ $DICE < 96 ]]; then
+    zsh ./credential_stuffing.sh;
+  elif [[ $DICE < 98 ]]; then
     zsh ./brute_force.sh;
-  elif [[ $DICE > 101 ]]; then
+  elif [[ $DICE < 101 ]]; then
     zsh ./brute_force_botnet.sh;
   fi
   date ;


### PR DESCRIPTION
Several users want to see perpetual data in their environment. This is a rough, early attempt at providing a continuous stream of our existing events.

Future iterations should include: 
* a cap on MAUs (e.g. 500 identities that we iterate through)
* parameterization for the probability of attacks as a CLI argument
* params for the frequency of events (it's 60 seconds now)
* params for the duration of the traffic (it is infinite now)
